### PR TITLE
Show arrow width (linear), update styles, fix nodes too big, fix upda…

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,7 +6,7 @@ export default function Header({ children, title }: IHeader) {
   const projectName = projectPath.split('/').pop();
 
   return (
-    <header className="flex flex-row items-center justify-between bg-sky-100 dark:bg-sky-900 p-4 gap-4">
+    <header className="flex flex-row items-center justify-between bg-sky-100 dark:bg-black border border-gray-100 dark:border-gray-800 p-2 gap-4">
       <div className="flex flex-row items-center justify-start">
         <Popover />
         <h1 className="ml-4 text-foreground">{projectName}</h1>

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -3,7 +3,7 @@ import Settings from '@/components/Settings';
 
 export default function Main({ children }: PropsWithChildren) {
   return (
-    <main className="flex flex-col md:flex-row bg-background text-foreground flex-1">
+    <main className="flex flex-col md:flex-row bg-background dark:bg-gray-950 text-foreground flex-1">
       <Settings />
       {children}
     </main>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -9,7 +9,7 @@ export default function Settings() {
     useSettings();
 
   return (
-    <div className="p-4 md:pt-14 border-r bg-gray-100 dark:bg-gray-800 border-r-gray-200 dark:border-r-gray-800">
+    <div className="p-4 md:pt-14 border-r bg-gray-100 dark:bg-emerald-950 border-r-gray-200 dark:border-r-gray-800">
       {/* Audit Download */}
       <div className="flex flex-row items-center">
         <Download size={8} className="mr-1" />

--- a/src/components/ZoomInput.tsx
+++ b/src/components/ZoomInput.tsx
@@ -7,6 +7,7 @@ export default function ZoomInput({ cyInstance }: IZoomInput) {
 
   useEffect(() => {
     if (!cyInstance) return;
+    cyInstance.on('zoom', () => setZoom(cyInstance.zoom()));
     setZoomToFit(cyInstance.zoom());
   }, [cyInstance]);
 
@@ -24,7 +25,7 @@ export default function ZoomInput({ cyInstance }: IZoomInput) {
   if (zoom === null) return;
 
   return (
-    <div className="p-4 flex items-center justify-center gap-2 text-foreground bg-background border-t border-t-gray-200 dark:border-t-gray-800">
+    <div className="p-4 flex items-center justify-center gap-2 text-foreground bg-background dark:bg-gray-950 border-t border-t-gray-200 dark:border-t-gray-800">
       <label
         htmlFor="zoom"
         className="text-sm text-gray-600"

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,3 +1,5 @@
+import type { EdgeDataDefinition, EdgeDefinition, NodeDataDefinition } from 'cytoscape';
+
 /**
  * General
  */
@@ -34,4 +36,19 @@ export interface IJavaImport {
   readonly name: string;
   readonly pkg: string;
   readonly isIntrinsic?: boolean;
+}
+
+/**
+ * Cytoscape
+ */
+export interface IPkgNodeData extends NodeDataDefinition {
+  readonly path: string;
+  readonly isIntrinsic?: boolean;
+}
+export interface IPkgEdgeData extends EdgeDataDefinition {
+  weight: number;
+}
+export interface IRawElementsDefinition {
+  readonly nodes: { data: IPkgNodeData }[];
+  readonly edges: Map<string, EdgeDefinition>;
 }

--- a/src/utils/cytoscape/buildGraph.ts
+++ b/src/utils/cytoscape/buildGraph.ts
@@ -1,11 +1,6 @@
-import type {
-  EdgeDefinition,
-  ElementsDefinition,
-  EdgeDataDefinition,
-  NodeDataDefinition,
-} from 'cytoscape';
+import type { EdgeDefinition, ElementsDefinition } from 'cytoscape';
 import type { IDirectory } from '@/utils/getParsedFileStructure';
-import type { IFile } from '@/types/types';
+import type { IFile, IPkgEdgeData, IPkgNodeData, IRawElementsDefinition } from '@/types/types';
 
 /**
  * Builds a weighted dependency graph based on package-level imports
@@ -75,16 +70,4 @@ export function buildGraph(dir: IDirectory) {
   };
 
   return elements;
-}
-
-interface IPkgNodeData extends NodeDataDefinition {
-  readonly path: string;
-  readonly isIntrinsic?: boolean;
-}
-interface IPkgEdgeData extends EdgeDataDefinition {
-  weight: number;
-}
-interface IRawElementsDefinition {
-  readonly nodes: { data: IPkgNodeData }[];
-  readonly edges: Map<string, EdgeDefinition>;
 }


### PR DESCRIPTION
- Show edge widths using linear from 0 to max found edges
- Prepare other modes for widths ready to put into settings, there is 'linear'|'log'|'quantile'
- Make edge arrow a bit bigger than before (was hard to see)

Additionally:
- Update zoom input if user zooms directly on graph
- Update styles